### PR TITLE
feat: Unify .mocked() implementation

### DIFF
--- a/Sources/TestSupport/Mocked.swift
+++ b/Sources/TestSupport/Mocked.swift
@@ -2,6 +2,15 @@ import Networking
 
 extension NetworkingComponent {
 
+  /// Mock a given request with a stub
+  public func mocked(
+    _ request: HTTPRequestData,
+    stub: StubbedResponseStream
+  ) -> some NetworkingComponent {
+    mocked(stub) { $0 ~= request }
+  }
+
+  /// Mock the provided stub, after evaluating the request via the check
   public func mocked(
     _ stub: StubbedResponseStream,
     check: @escaping @Sendable (HTTPRequestData) -> Bool
@@ -9,49 +18,24 @@ extension NetworkingComponent {
     mocked { check($0) ? stub : nil }
   }
 
+  /// Evaluate the request, returning a stub to use for mocking, or nil to pass through without mocking
   public func mocked(
-    _ request: HTTPRequestData,
-    stub: StubbedResponseStream
+    _ mock: @escaping @Sendable (HTTPRequestData) -> StubbedResponseStream?
   ) -> some NetworkingComponent {
-    mocked { $0 ~= request ? stub : nil }
-  }
-
-  public func mocked(
-    _ stub: @escaping @Sendable (HTTPRequestData) -> StubbedResponseStream?
-  ) -> some NetworkingComponent {
-    modified(Mocked(mock: stub))
-  }
-}
-
-struct Mocked: NetworkingModifier {
-  let mock: @Sendable (HTTPRequestData) -> StubbedResponseStream?
-
-  @NetworkEnvironment(\.instrument) var instrument
-
-  init(mock: @escaping @Sendable (HTTPRequestData) -> StubbedResponseStream?) {
-    self.mock = mock
-  }
-
-  func resolve(upstream: some NetworkingComponent, request: HTTPRequestData) -> HTTPRequestData {
-    request  // Note: We actually do not want to resolve the request to be mocked
-  }
-
-  func send(upstream: some NetworkingComponent, request: HTTPRequestData) -> ResponseStream<
-    HTTPResponseData
-  > {
-    guard let stub = mock(request) else {
-      return upstream.send(request)
-    }
-    return ResponseStream { continuation in
-      Task {
-        await instrument?.measureElapsedTime("Mocked")
-        stub(request).redirect(into: continuation)
+    mocked { upstream, request in
+      ResponseStream { continuation in
+        Task {
+          if let stub = mock(request) {
+            stub(request).redirect(into: continuation)
+          } else {
+            upstream.send(request).redirect(into: continuation)
+          }
+        }
       }
     }
   }
-}
 
-extension NetworkingComponent {
+  /// Create a fully custom mock, given the upstream component, and request, returning a response stream.
   public func mocked(
     _ block: @escaping @Sendable (NetworkingComponent, HTTPRequestData) async -> ResponseStream<
       HTTPResponseData
@@ -61,7 +45,7 @@ extension NetworkingComponent {
   }
 }
 
-struct CustomMocked: NetworkingModifier {
+private struct CustomMocked: NetworkingModifier {
   let block: @Sendable (NetworkingComponent, HTTPRequestData) async -> ResponseStream<HTTPResponseData>
 
   func resolve(upstream: some NetworkingComponent, request: HTTPRequestData) -> HTTPRequestData {

--- a/Tests/NetworkingTests/Components/MetricsTests.swift
+++ b/Tests/NetworkingTests/Components/MetricsTests.swift
@@ -33,8 +33,8 @@ final class MetricsTests: XCTestCase {
         return
       }
 
-      XCTAssertNoDifference(measurements.map(\.label), ["Delay", "Mocked"])
-      XCTAssertNoDifference(measurements.map(\.duration), [.zero, .seconds(3)])
+      XCTAssertNoDifference(measurements.map(\.label), ["Delay"])
+      XCTAssertNoDifference(measurements.map(\.duration), [.zero])
     }
   }
 }


### PR DESCRIPTION
Ultimately - all `.mocked()` go through the "custom mock" modifier.