### PR TITLE
feat: Network client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ package.platforms = [
 // MARK: - 🧸 Module Names
 
 let Helpers = "Helpers"
+let NetworkClient = "NetworkClient"
 let Networking = "Networking"
 let OAuth = "OAuth"
 let TestSupport = "TestSupport"
@@ -38,6 +39,24 @@ let 📦 = Module.builder(
 Helpers
   <+ 📦 {
     $0.createUnitTests = false
+  }
+
+NetworkClient
+  <+ 📦 {
+    $0.createProduct = .library(nil)
+    $0.createUnitTests = false
+    $0.dependsOn = [
+      Networking
+    ]
+  }
+
+NetworkClient.live
+  <+ 📦 {
+    $0.createProduct = .library(nil)
+    $0.createUnitTests = false
+    $0.dependsOn = [
+      NetworkClient
+    ]
   }
 
 Networking
@@ -184,6 +203,7 @@ extension String {
   }
   var snapshotTests: String { "\(self)SnapshotTests" }
   var tests: String { "\(self)Tests" }
+  var live: String { "\(self)Live" }
 }
 
 struct Module {

--- a/Sources/NetworkClient/NetworkClient.swift
+++ b/Sources/NetworkClient/NetworkClient.swift
@@ -1,0 +1,19 @@
+import Dependencies
+import DependenciesMacros
+import Networking
+
+@DependencyClient
+public struct NetworkClient: Sendable {
+  public var networkClient: @Sendable () -> any NetworkingComponent = { Networking.Unimplemented() }
+}
+
+extension NetworkClient: TestDependencyKey {
+  public static let testValue = NetworkClient()
+}
+
+extension DependencyValues {
+  public var networkClient: NetworkClient {
+    get { self[NetworkClient.self] }
+    set { self[NetworkClient.self] = newValue }
+  }
+}

--- a/Sources/NetworkClient/NetworkClient.swift
+++ b/Sources/NetworkClient/NetworkClient.swift
@@ -4,7 +4,7 @@ import Networking
 
 @DependencyClient
 public struct NetworkClient: Sendable {
-  public var networkClient: @Sendable () -> any NetworkingComponent = { Networking.Unimplemented() }
+  public var network: @Sendable () -> any NetworkingComponent = { UnimplementedNetwork() }
 }
 
 extension NetworkClient: TestDependencyKey {

--- a/Sources/NetworkClientLive/NetworkClient+Live.swift
+++ b/Sources/NetworkClientLive/NetworkClient+Live.swift
@@ -1,0 +1,14 @@
+import Dependencies
+import Foundation
+import NetworkClient
+import Networking
+
+extension NetworkClient: DependencyKey {
+  public static let liveValue: Self = {
+    let stack = URLSession.shared
+      .throttled(max: 3)
+      .automaticRetry()
+      .duplicatesRemoved()
+    return NetworkClient { stack }
+  }()
+}

--- a/Sources/Networking/Components/Unimplemented.swift
+++ b/Sources/Networking/Components/Unimplemented.swift
@@ -1,0 +1,12 @@
+public struct Unimplemented: NetworkingComponent {
+
+  public init() {}
+
+  public func send(_ request: HTTPRequestData) -> ResponseStream<HTTPResponseData> {
+    ResponseStream { continuation in
+      continuation.finish(
+        throwing: StackError(request: request, kind: .unimplemented)
+      )
+    }
+  }
+}

--- a/Sources/Networking/Components/UnimplementedNetwork.swift
+++ b/Sources/Networking/Components/UnimplementedNetwork.swift
@@ -1,4 +1,4 @@
-public struct Unimplemented: NetworkingComponent {
+public struct UnimplementedNetwork: NetworkingComponent {
 
   public init() {}
 

--- a/Sources/Networking/Errors/StackError.swift
+++ b/Sources/Networking/Errors/StackError.swift
@@ -14,6 +14,7 @@ package struct StackError: Error {
     case timeout
     case unauthorized
     case unknown
+    case unimplemented
   }
 
   let info: Info


### PR DESCRIPTION
- [x] Adds `UnimplementedNetwork` to help with writing NetworkClient dependency clients.
- [x] Adds a `NetworkClient` dependency.
    - [x] Adds `NetworkClient` library which exposes `@Dependency(\.networkClient)` which itself has a `network()` property to return `any NetworkingComponent`.
    - [x] Adds `NetworkClientLive` library which adds a `DependencyKey` conformance with a reasonable `liveValue` based on `URLSession.shared`.
   

 